### PR TITLE
remove floating cart summary

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/checkout",
-  "version": "1.209.1",
+  "version": "1.209.2",
   "private": true,
   "description": "Browser-based application providing a seamless UI for BigCommerce shoppers to complete their checkout.",
   "license": "MIT",

--- a/src/app/checkout/Checkout.tsx
+++ b/src/app/checkout/Checkout.tsx
@@ -287,13 +287,13 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
                 <MobileView>
                     { matched => {
                         if (matched) {
-                            return <div className="test-02-wrapper layout-cart">
+                            return <div className="cart-summary-wrapper-mobile layout-cart">
                                     <LazyContainer>
                                         <CartSummary />
                                     </LazyContainer>
                                     </div>;
                         } else {
-                            return <br className="test-02-wrapper" />;
+                            return <span></span>;
                         }
 
                     } }
@@ -485,9 +485,7 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
             <MobileView>
                 { matched => {
                     if (matched) {
-                        return <LazyContainer>
-                            <CartSummaryDrawer />
-                        </LazyContainer>;
+                        return <span></span>;
                     }
 
                     return <aside className="layout-cart">


### PR DESCRIPTION
## What?
... Display the cart summary on the top of checkout page on mobile by default
... Remove the floating summary on mobile
## Why?
... We want to display the cart summary on the top of checkout page on mobile by default as the AB Testing is approve
So we don't need to hide it and display when the test class is added. It should work by default 

## Testing / Proof
...

@bigcommerce/checkout
